### PR TITLE
facedetector_e: Fix crash due to 'invalid preview size'

### DIFF
--- a/facedetector_e-lab/res/layout/activity_main.xml
+++ b/facedetector_e-lab/res/layout/activity_main.xml
@@ -20,6 +20,14 @@
         android:layout_below="@id/button480"
         android:text="@string/Cam768p" />
      
+     <Button
+        android:id="@+id/button1080"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:layout_below="@id/button768"
+        android:text="@string/Cam1080p" />
+
     <Button
         android:id="@+id/button240"
         android:layout_width="wrap_content"

--- a/facedetector_e-lab/res/values/strings.xml
+++ b/facedetector_e-lab/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">e-Lab Face Detector</string>
+    <string name="Cam1080p">Start 1080p</string>
     <string name="Cam768p">Start 768p</string>
     <string name="Cam480p">Start 480p</string>
     <string name="Cam240p">Start 240p</string>

--- a/facedetector_e-lab/src/com/torchandroid/facedemo/CameraActivity.java
+++ b/facedetector_e-lab/src/com/torchandroid/facedemo/CameraActivity.java
@@ -59,8 +59,8 @@ public class CameraActivity extends Activity
 	    camHolder.setType(SurfaceHolder.SURFACE_TYPE_PUSH_BUFFERS);
 	         
 	    mainLayout = (FrameLayout) findViewById(R.id.frameLayout);
-	    mainLayout.addView(camView, new LayoutParams(1280, 768));
-	    mainLayout.addView(MyCameraClass, new LayoutParams(1280, 768));
+	    mainLayout.addView(camView, new LayoutParams(1920, 1080));
+	    mainLayout.addView(MyCameraClass, new LayoutParams(1920, 1080));
 	    
 	}
 	

--- a/facedetector_e-lab/src/com/torchandroid/facedemo/CameraClass.java
+++ b/facedetector_e-lab/src/com/torchandroid/facedemo/CameraClass.java
@@ -1,6 +1,7 @@
 package com.torchandroid.facedemo;
 
 import java.io.IOException;
+import java.util.List;
 import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.ImageFormat;
@@ -35,8 +36,8 @@ public class CameraClass implements SurfaceHolder.Callback, Camera.PreviewCallba
 	PreviewSizeWidth = PreviewlayoutWidth;
 	PreviewSizeHeight = PreviewlayoutHeight;
 	MycameraClass = cameraClass;
-	bitmap = Bitmap.createBitmap(1280, 768, Bitmap.Config.ARGB_8888);
-	pixels = new int[1280*768];
+	bitmap = Bitmap.createBitmap(1920, 1080, Bitmap.Config.ARGB_8888);
+	pixels = new int[1920*1080];
     }
 	  
     public void onPreviewFrame(byte[] arg0, Camera arg1) 
@@ -60,9 +61,10 @@ public class CameraClass implements SurfaceHolder.Callback, Camera.PreviewCallba
 	Parameters parameters;
 	   
 	parameters = mCamera.getParameters();
+    List<Camera.Size> sizes = parameters.getSupportedPreviewSizes();
 	// Set the camera preview size
 	parameters.setPreviewFormat(ImageFormat.YV12);
-	parameters.setPreviewSize(1280, 768);
+	parameters.setPreviewSize(sizes.get(0).width, sizes.get(0).height);
 	   
 	imageFormat = parameters.getPreviewFormat();
 	   
@@ -130,7 +132,7 @@ public class CameraClass implements SurfaceHolder.Callback, Camera.PreviewCallba
 			wholeLoop = (float) ((stop-start)/1000);
 			fps = 1/wholeLoop;
 				
-			bitmap.setPixels(pixels, 0, 1280, 0, 0, 1280, 768);
+			bitmap.setPixels(pixels, 0, 1920, 0, 0, 1920, 1080);
 			MycameraClass.setImageBitmap(bitmap);
 	
 			networkPercentage = (networkLoop/wholeLoop)*100;

--- a/facedetector_e-lab/src/com/torchandroid/facedemo/MainActivity.java
+++ b/facedetector_e-lab/src/com/torchandroid/facedemo/MainActivity.java
@@ -21,7 +21,7 @@ public class MainActivity extends Activity {
 	public static int width, height;
 	static TextView infoText;
 
-	Button button768, button480, button1080;
+	Button button768, button480, button1080, button240;
 	   
 	@Override
 	public void onCreate(Bundle savedInstanceState) 
@@ -30,9 +30,10 @@ public class MainActivity extends Activity {
 	    
 	    setContentView(R.layout.activity_main);	   
 
+	    button1080 = (Button) findViewById(R.id.button1080);
 	    button768 = (Button) findViewById(R.id.button768);
 	    button480 = (Button) findViewById(R.id.button480);
-	    button1080 = (Button) findViewById(R.id.button240);
+	    button240 = (Button) findViewById(R.id.button240);
 	    infoText = (TextView) this.findViewById(R.id.info);
 	    
 	    infoText.setText("This network requires 183.4 MOPs.\nIt has 3 layers like so -\n\nSpatial " +
@@ -40,6 +41,7 @@ public class MainActivity extends Activity {
 	    
 	    button768.setOnClickListener(buttonHandler);
 	    button480.setOnClickListener(buttonHandler);
+	    button240.setOnClickListener(buttonHandler);
 	    button1080.setOnClickListener(buttonHandler);
 	}
 	
@@ -50,6 +52,10 @@ public class MainActivity extends Activity {
 		{
 			switch(v.getId())
 			{
+			case R.id.button1080:
+				width = 1920;
+				height = 1080;
+				break;
 			case R.id.button768:
 				width = 1280;
 				height = 768;


### PR DESCRIPTION
Current code crashes when it's used with phones that doesn't support camera preview of size 1280x768. Correct method is to use one of the supported camera preview sizes which can be retrieved via `getSupportedPreviewSizes()` method.
